### PR TITLE
Update docs for Model Insights and AI chat

### DIFF
--- a/AI_CHAT_SETUP.md
+++ b/AI_CHAT_SETUP.md
@@ -1,8 +1,8 @@
-# BMW Motorrad AI Chat Assistant
+# AI Chat Assistant
 
 ## Overview
 
-The AI Chat Assistant is now integrated into the BMW Motorrad Segment Insights dashboard, providing intelligent analysis and insights based on your market data.
+The AI Chat Assistant is integrated into the Model Insights dashboard, providing intelligent analysis based on the selected market.
 
 ## Features
 
@@ -92,23 +92,19 @@ npm run dev-server
 
 ## AI Assistant Capabilities
 
-The AI assistant is specialized in BMW Motorrad market analysis and can help with:
+The AI assistant answers questions about R 12 G/S consumer conversations and reports:
 
-- **Market Insights**: Analysis of specific European markets
-- **Competitor Analysis**: Understanding competitive positioning
-- **Strategic Recommendations**: Actionable insights for market strategy
+- **Market Insights**: Analysis of specific markets
 - **Data Interpretation**: Explaining charts, metrics, and trends
-- **Executive Summaries**: Key takeaways and highlights
+- **Report References**: Locating details in the uploaded PDFs
 
 ## Example Questions
 
 Try asking the AI assistant questions like:
 
 - "What are the key insights for the French market?"
-- "How does BMW compare to competitors in Germany?"
-- "What are the strategic recommendations for Italy?"
-- "Explain the WRI scores for Nordic markets"
-- "What trends are emerging in the electric motorcycle segment?"
+- "How do riders in Italy feel about the R 12 G/S?"
+- "Where in the reports is suspension discussed?"
 
 ## Troubleshooting
 

--- a/AI_INSIGHTS_INTEGRATION.md
+++ b/AI_INSIGHTS_INTEGRATION.md
@@ -10,7 +10,7 @@ The R12GSConsumerAnalysis component has been enhanced with AI-powered insights t
 - **Toggle Button**: "🤖 Show/Hide AI Insights" button in the header
 - **Generate Button**: "Generate Insights" button that appears when insights are shown
 - **Auto-generation**: Insights are automatically generated when filters change (with 1-second debounce)
-- **Real-time Analysis**: Analyzes filtered data and provides actionable recommendations
+- **Real-time Analysis**: Analyzes filtered data in real time
 
 ### 2. Mini AI Insights
 - **Contextual Insights**: Mini AI insights appear in specific dashboard sections
@@ -63,7 +63,7 @@ const handleToggleInsights = () => {
 ### Integration Points
 
 1. **Header Controls**: AI insights toggle and generate buttons
-2. **Main Panel**: Full AI insights panel with summary, findings, and recommendations
+2. **Main Panel**: Full AI insights panel with summary and findings
 3. **Chart Sections**: Mini insights in sentiment, theme, and platform charts
 4. **Filter Integration**: Automatic insights generation based on QuoteExplorer filters
 
@@ -94,7 +94,6 @@ const handleToggleInsights = () => {
 - System prompt tailored for BMW R 12 G/S consumer analysis
 - Context-aware prompts based on active filters
 - Data-driven insights with specific percentages and statistics
-- Actionable recommendations for business decisions
 
 ## Styling
 

--- a/OPENAI_API_SETUP.md
+++ b/OPENAI_API_SETUP.md
@@ -1,82 +1,22 @@
-# OpenAI API Setup Guide
+# OpenAI API Setup
 
-## 🎯 **Current Status: ✅ API Key Configured**
+## Get an API key
 
-Great news! Your OpenAI API key is now properly configured and the AI insights should be working with real AI analysis.
+1. Sign up at [OpenAI](https://platform.openai.com/) and create an API key.
 
-### **What's Fixed:**
-- ✅ **API Key Detected**: `REACT_APP_OPENAI_API_KEY` is now in your `.env` file
-- ✅ **Real AI Insights**: No more demo mode - you'll get actual AI-powered analysis
-- ✅ **No Crashes**: The app is stable and working properly
-- ✅ **Dynamic Analysis**: Insights are generated using OpenAI's GPT-4o-mini model
+## Configure the dashboard
 
-## 🚀 **How to Test Real AI Insights**
+Add the following to your `.env` file:
 
-1. **Navigate** to the R12GSConsumerAnalysis dashboard
-2. **Click** "🤖 Show AI Insights" button
-3. **Apply filters** using the QuoteExplorer component
-4. **Wait 2-5 seconds** for real AI analysis (instead of instant demo insights)
-5. **View** AI-powered insights with natural language analysis
+```
+OPENAI_API_KEY=your_openai_api_key
+R12GS_VECTOR_STORE_ID=your_vector_store_id
+R12GS_REPORTS_VECTOR_STORE_ID=your_reports_vector_store_id
+```
 
-## 🔧 **What You Should See Now**
+Restart the development server after updating the file.
 
-### **Real AI Features:**
-- 🤖 **Natural Language Analysis**: AI understands context and generates human-like insights
-- 📊 **Dynamic Recommendations**: Tailored suggestions based on your specific data
-- 🧠 **Pattern Recognition**: AI identifies trends and correlations you might miss
-- 💡 **Contextual Insights**: Different analysis for different sections and filters
+## Verify
 
-### **No More Demo Indicators:**
-- ❌ No yellow "Demo Mode" banner
-- ❌ No "API key required" messages
-- ✅ Real AI-generated content
+Launch the dashboard and use the AI chat to confirm responses are generated.
 
-## 💰 **Cost Information**
-
-- **GPT-4o-mini**: ~$0.00015 per 1K input tokens
-- **Typical cost per insight**: ~$0.001-0.005
-- **Monthly usage**: Depends on your analysis frequency
-
-## 🛡️ **Security Notes**
-
-Your API key is properly configured:
-- ✅ **Environment Variable**: Stored in `.env` file (not in code)
-- ✅ **React Compatible**: Uses `REACT_APP_` prefix for browser access
-- ✅ **Secure**: Not committed to version control
-
-## 🔍 **Troubleshooting**
-
-### **Still seeing demo mode?**
-1. Check browser console for API key detection logs
-2. Verify the app was restarted after adding the key
-3. Clear browser cache and refresh
-
-### **API errors?**
-1. Verify your OpenAI account has credits
-2. Check for rate limits
-3. Ensure the API key is valid and active
-
-### **Slow responses?**
-- Real AI analysis takes 2-5 seconds
-- This is normal for GPT-4o-mini model
-- Much faster than demo mode but more intelligent
-
-## 📊 **Demo vs Real AI Comparison**
-
-| Feature | Demo Mode | Real AI (Now Active) |
-|---------|-----------|----------------------|
-| **Speed** | Instant | 2-5 seconds |
-| **Cost** | Free | ~$0.001-0.005 per insight |
-| **Quality** | Data-based patterns | Advanced AI analysis |
-| **Context** | Statistical analysis | Natural language understanding |
-| **Flexibility** | Pre-defined patterns | Dynamic responses |
-
-## 🎉 **You're All Set!**
-
-Your AI insights integration is now fully functional with:
-- 🤖 **Real AI-powered insights**
-- 🧠 **Advanced natural language analysis**
-- 📈 **Deeper pattern recognition**
-- 💡 **More nuanced recommendations**
-
-Enjoy your intelligent BMW R 12 G/S consumer analysis! 🏍️✨ 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# BMW Touring Segment Dashboard
+# Model Insights Dashboard
 
-This project contains a React dashboard that displays data generated from markdown reports, featuring interactive visualizations, competitor analysis, and PDF report viewing capabilities.
+This React application displays consumer conversations for the BMW R 12 G/S and provides AI‑powered insights and chat support.
 
 ## Prerequisites
 
@@ -9,184 +9,72 @@ This project contains a React dashboard that displays data generated from markdo
 
 ## Setup
 
-1. Clone the repository:
+1. Clone the repository and install dependencies:
    ```bash
-   git clone https://github.com/rachel-s123/bmw_touring_segment_q1.git
-   cd bmw_touring_segment_q1
-   ```
-
-2. Install dependencies:
-   ```bash
+   git clone <repository_url>
+   cd social-intelligence-dashboard
    npm install
    ```
 
-3. Install additional required packages for PDF viewing:
-   ```bash
-   npm install react-pdf @react-pdf/renderer
-   ```
-
-## Report Structure
-
-Place R 12 G/S consumer analysis markdown reports in:
-
-- `reports/r12gs_consumer_analysis/` - R 12 G/S consumer analysis reports
-
-When creating new R 12 G/S consumer analysis markdown files, copy `templates/model_insights_template.md`
-into the `reports/r12gs_consumer_analysis/` directory and fill in the sections with your
-market-specific insights.
-
 ## Data Generation
 
-The dashboard requires several data files to be generated from the markdown reports. These files are located in `src/data/`:
+The dashboard uses a single data file in `src/data/r12gsConsumerData.js`.
+Generate it from the markdown reports with:
 
-- `wriData.js` - WRI data
-- `wriInsights.js` - WRI insights
-- `competitorData.js` - Competitor analysis data
-- `conversationData.js` - Conversation data
-- `executiveSummaries.js` - Executive summaries
-- `marketRecommendations.js` - Market recommendations
-- `marketIntroductions.js` - Market introductions
-- `marketSources.js` - Market sources
- - `attributeResonance.js` - Attribute resonance data
- - `r12gsConsumerData.js` - R 12 G/S consumer conversation data
-
-Generate these files by running the following scripts:
 ```bash
-# Generate WRI data
-npm run generate-wri-data
-
-# Generate competitor analysis data
-npm run generate-competitor-data
-
-# Generate conversation data
-npm run generate-conversation-data
-
-# Generate executive summaries
-npm run generate-executive-summaries
-
-# Generate market recommendations
-npm run generate-market-recommendations
-
-# Generate market introductions
-npm run generate-market-introductions
-
-# Generate R 12 G/S consumer data
 npm run generate-r12gs-consumer-data
 ```
 
-## PDF Reports
+## Market Selection
 
-Store R 12 G/S market PDFs in the `vector_reports/r12gs/` directory with the following naming convention:
+Use the **Select Market** dropdown at the top of the dashboard to change the
+active market. The list of markets comes from `r12gsConsumerData.js`.
 
-```
-vector_reports/r12gs/{country}-r12gs.pdf
-```
+## Vector Store & OpenAI Setup
 
-Example: `vector_reports/r12gs/france-r12gs.pdf`
-
-The PDF viewer supports:
-- Continuous scrolling
-- Fullscreen mode
-- Zoom controls
-- Page navigation
-
-## Vector Store Setup
-
-To enable AI search of the R 12 G/S PDF reports, upload the files in `vector_reports/r12gs/` to
-a new OpenAI vector store:
-
-```bash
-node scripts/create_report_vector_store.js
-```
-
-Copy the printed ID and set it in your `.env` file as `R12GS_REPORTS_VECTOR_STORE_ID`.
-See [REPORT_VECTOR_STORE_SETUP.md](REPORT_VECTOR_STORE_SETUP.md) for details.
+Configure the application with your OpenAI key and vector store IDs in
+`.env`. See
+[OPENAI_API_SETUP.md](OPENAI_API_SETUP.md) and
+[REPORT_VECTOR_STORE_SETUP.md](REPORT_VECTOR_STORE_SETUP.md) for detailed steps.
 
 ## Running the Dashboard
 
-1. Start the development server:
-   ```bash
-   npm start
-   ```
+Start the development server and open `http://localhost:3000`:
 
-2. Open your browser and navigate to `http://localhost:3000`
+```bash
+npm start
+```
 
-## Dashboard Features
+## Using the AI Chatbot
 
-1. **Market Overview**
-   - High-level summary of the market landscape
-   - Key trends and market context
-   - Introduction to the selected market
-
-2. **Executive Summary**
-   - Concise summary of findings for the selected market
-   - Strategic implications for BMW's touring segment
-   - Key takeaways and highlights
-
-3. **Attribute Resonance**
-   - Analysis of how product attributes resonate with consumers
-   - Attribute scoring and importance
-   - Visualizations of attribute performance
-
-4. **Market Insights**
-   - In-depth analysis of market dynamics and consumer behavior
-   - Insights into market drivers and barriers
-   - Data-driven findings for the selected market
-
-5. **Competitor Analysis**
-   - Share of Voice visualization (Q1 2025)
-   - Strengths and weaknesses of major competitors
-   - Market opportunities and gaps to exploit
-   - Interactive charts and competitor breakdowns
-
-6. **Recommendations**
-   - Actionable recommendations for BMW's touring segment
-   - Strategic suggestions based on data analysis
-   - Market entry or product development guidance
+Click the 🤖 button in the bottom‑right corner to open the chat panel.
+The assistant answers questions about the selected market using the data
+and uploaded PDF reports. See [AI_CHAT_SETUP.md](AI_CHAT_SETUP.md) for
+details.
 
 ## Troubleshooting
 
-1. If PDFs are not loading:
-   - Ensure PDF files are in the correct directory (`vector_reports/r12gs/`)
-   - Check file naming convention
-   - Verify PDF file permissions
-
-2. If data is not displaying:
-   - Run all data generation scripts
+1. If data is not displaying:
+   - Run `npm run generate-r12gs-consumer-data`
    - Check console for errors
-   - Verify markdown files are in correct directories
-   - Ensure all required data files exist in `src/data/`
+   - Verify markdown files are in the correct directory
 
-3. If the dashboard fails to start:
+2. If the dashboard fails to start:
    - Clear npm cache: `npm cache clean --force`
    - Delete node_modules: `rm -rf node_modules`
    - Reinstall dependencies: `npm install`
 
-## Contributing
-
-1. Create a new branch for your changes
-2. Make your modifications
-3. Run all data generation scripts
-4. Test the dashboard locally
-5. Submit a pull request
-
-## License
-
-This project is proprietary and confidential. All rights reserved.
-
 ## Security
 
-### Search Engine Indexing Prevention
-The application is configured to prevent search engine indexing through meta tags in the HTML head. This ensures that the dashboard and its contents remain private and are not discoverable through search engines. The following meta tags are implemented:
+The application includes meta tags that prevent search engine indexing:
 
 ```html
 <meta name="robots" content="noindex, nofollow" />
 <meta http-equiv="X-Robots-Tag" content="noindex, nofollow" />
 ```
 
-These tags instruct search engines to:
-- Not index the page content
-- Not follow any links on the page
-- Not cache the page
+These tags keep the dashboard and its contents private.
 
-This security measure helps maintain the confidentiality of the dashboard and its data.
+## License
+
+This project is proprietary and confidential. All rights reserved.

--- a/REPORT_VECTOR_STORE_SETUP.md
+++ b/REPORT_VECTOR_STORE_SETUP.md
@@ -1,6 +1,6 @@
 # Report Vector Store Setup
 
-This project can search R 12 G/S market PDF reports using an OpenAI vector store. The repository includes sample PDFs in `vector_reports/r12gs/`.
+The Model Insights dashboard can search R 12 G/S market PDF reports using an OpenAI vector store. The repository includes sample PDFs in `vector_reports/r12gs/`.
 
 ## Creating the Vector Store
 


### PR DESCRIPTION
## Summary
- Simplify README for Model Insights dashboard and AI chatbot
- Clarify chat setup and remove references to deprecated modules
- Streamline AI insights, vector store, and OpenAI key documentation

## Testing
- `npm test` *(fails: react-scripts not found)*
- `npm run lint` *(fails: ESLint config not found)*

------
https://chatgpt.com/codex/tasks/task_b_68b02b45c8708331a3028210266956a7